### PR TITLE
use PATH to find ocaml, rather than hardwire

### DIFF
--- a/tools/insert_variant
+++ b/tools/insert_variant
@@ -1,6 +1,6 @@
 #!/bin/sh
 # (*
-exec /usr/local/bin/ocaml "$0" "$@"
+exec /usr/bin/env ocaml "$0" "$@"
 *) directory ".";;
 
 (* Note:


### PR DESCRIPTION
use $PATH to find ocaml, rather than hardwire
